### PR TITLE
Another case of missing lodash import that is triggered only on AWS

### DIFF
--- a/lambdas/sentinel/index.js
+++ b/lambdas/sentinel/index.js
@@ -10,7 +10,7 @@ const moment = require('moment')
 const through2 = require('through2')
 const satlib = require('sat-api-lib')
 const local = require('kes/src/local')
-
+const _ = require('lodash')
 
 const collection = {
   "c:id": "sentinel-2-l1c",


### PR DESCRIPTION
Not sure why this wasn't triggered before... not sure I understand Node.js scoping rules.