### PR TITLE
[WIP] support for ingesting metadata in STAC format from SNS (new packaging)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ package-lock.json
 yarn.lock
 *.lerna_backup
 _book
+*~

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "description": "An instance of sat-api for Development Seed",
   "main": "index.js",
   "scripts": {
-    "linkall": "yarn link @sat-utils/api @sat-utils/api-lib @sat-utils/ingest @sat-utils/landsat @sat-utils/manager @sat-utils/sentinel",
+    "linkall": "yarn link @sat-utils/api @sat-utils/api-lib @sat-utils/ingest @sat-utils/landsat @sat-utils/manager @sat-utils/sentinel @sat-utils/sns-ingest",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/packages/api-lib/libs/es.js
+++ b/packages/api-lib/libs/es.js
@@ -20,7 +20,12 @@ async function connect() {
 
   // use local client
   if (!process.env.ES_HOST) {
-    client = new elasticsearch.Client({ host: 'localhost:9200' })
+    if (!process.env.ES_TEST_HOST) {
+      client = new elasticsearch.Client({ host: 'localhost:9200' })
+    }
+    else {
+      client = new elasticsearch.Client({ host: process.env.ES_TEST_HOST })
+    }
   }
   else {
     await new Promise((resolve, reject) => AWS.config.getCredentials((err) => {

--- a/packages/api/template/cloudformation.template.yml
+++ b/packages/api/template/cloudformation.template.yml
@@ -81,6 +81,13 @@ Resources:
                 - es:*
                 Resource:
                 - "arn:aws:es:*:*:domain/*"
+
+              # Allow access to SQS
+              - Effect: Allow
+                Action:
+                - sqs:*
+                Resource: arn:aws:sqs:*:*:*
+
   StepsRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -433,7 +440,7 @@ Resources:
       Runtime: {{# if runtime}}{{runtime}}{{else}}nodejs8.10{{/if}}
       Timeout: {{timeout}}
       Tags:
-        - Key: StackName 
+        - Key: StackName
           Value: {{../stackName}}
       {{#each ../tags}}
         - Key: {{@key}}
@@ -455,6 +462,21 @@ Resources:
 {{/each}}
   #################################################
   # Lambda config END
+  #################################################
+
+  #################################################
+  # STAC SNS Feed START
+  #################################################
+{{#each stacsnsfeed}}
+  {{name}}Queue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: {{MessageRetentionPeriod}}
+      QueueName: {{../stackName}}-{{name}}
+
+{{/each}}
+  #################################################
+  # STAC SNS Feed END
   #################################################
 
 Outputs:

--- a/packages/api/template/cloudformation.template.yml
+++ b/packages/api/template/cloudformation.template.yml
@@ -474,7 +474,56 @@ Resources:
       MessageRetentionPeriod: {{MessageRetentionPeriod}}
       QueueName: {{../stackName}}-{{name}}
 
+  {{name}}QueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+  #        !Sub |
+        Fn::Sub:
+          - |
+            {
+            "Version": "2012-10-17",
+            "Id": "${id}",
+            "Statement": [{
+              "Sid": "${sid}",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Action": "SQS:SendMessage",
+              "Resource": "${queueArn}",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": "{{topic}}"
+                }
+              }
+              }]
+            }
+          - { queueArn: !GetAtt [{{name}}Queue, Arn], id: {{name}}QueuePolicyId, sid: {{name}}QueuePolicySId }
+      Queues:
+        - !Ref {{name}}Queue
+
+#            Fn::Sub:
+#              - |
+#                {
+#                  "satellite": "landsat",
+#                  "arn": "${stateMachineArn}",
+#                  "maxFiles": 8,
+#                  "maxLambdas": 10,
+#                  "linesPerFile": 300
+#                }
+#              - stateMachineArn: !Ref LandsatMetadataProcessorStateMachine
+
+  {{name}}Subscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !GetAtt [{{name}}Queue, Arn]
+      Protocol: sqs
+      TopicArn: {{topic}}
+
 {{/each}}
+
+
   #################################################
   # STAC SNS Feed END
   #################################################

--- a/packages/api/template/cloudformation.template.yml
+++ b/packages/api/template/cloudformation.template.yml
@@ -478,7 +478,6 @@ Resources:
     Type: AWS::SQS::QueuePolicy
     Properties:
       PolicyDocument:
-  #        !Sub |
         Fn::Sub:
           - |
             {
@@ -503,23 +502,19 @@ Resources:
       Queues:
         - !Ref {{name}}Queue
 
-#            Fn::Sub:
-#              - |
-#                {
-#                  "satellite": "landsat",
-#                  "arn": "${stateMachineArn}",
-#                  "maxFiles": 8,
-#                  "maxLambdas": 10,
-#                  "linesPerFile": 300
-#                }
-#              - stateMachineArn: !Ref LandsatMetadataProcessorStateMachine
-
   {{name}}Subscription:
     Type: AWS::SNS::Subscription
     Properties:
       Endpoint: !GetAtt [{{name}}Queue, Arn]
       Protocol: sqs
       TopicArn: {{topic}}
+
+  {{name}}QueueLambdaTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: {{BatchSize}}
+      EventSourceArn: !GetAtt [{{name}}Queue, Arn]
+      FunctionName: !Ref snsingestLambdaFunction
 
 {{/each}}
 

--- a/packages/api/template/config.yml
+++ b/packages/api/template/config.yml
@@ -23,6 +23,8 @@ default:
     cbersfeed:
       name: CBERS
       topic: arn:aws:sns:us-east-1:769537946825:cbers-2-stac-CBERSSTACItemTopic-N0MZUA5EIQC9
+      # Retention period for messages in SQS that will receive
+      # the feed's STAC items
       MessageRetentionPeriod: 1209600
 
   lambdas:

--- a/packages/api/template/config.yml
+++ b/packages/api/template/config.yml
@@ -1,7 +1,7 @@
 default:
   stackName: sat-api-v3
 
-  system_bucket: change-me 
+  system_bucket: change-me
 
   tags:
     project: sat-api
@@ -14,16 +14,31 @@ default:
     version: '6.0'
     instanceCount: 1
     instanceType: t2.small.elasticsearch
-    volumeSize: 35 
+    volumeSize: 35
 
   apis:
     - name: stac
+
+  stacsnsfeed:
+    cbersfeed:
+      name: CBERS
+      topic: arn:aws:sns:us-east-1:769537946825:cbers-2-stac-CBERSSTACItemTopic-N0MZUA5EIQC9
+      MessageRetentionPeriod: 1209600
 
   lambdas:
     landsat:
       source: 'node_modules/@sat-utils/landsat/dist/'
       handler: index.handler
       timeout: 300
+      memory: 1024
+      envs:
+        ES_HOST: "!GetAtt {{es.name}}Domain.DomainEndpoint"
+    snsingest:
+      source: 'node_modules/@sat-utils/sns-ingest/dist/'
+      handler: index.handler
+      # The timeout for this function must be less than the SQS
+      # visibility timeout, currently set at the 30s default
+      timeout: 28
       memory: 1024
       envs:
         ES_HOST: "!GetAtt {{es.name}}Domain.DomainEndpoint"

--- a/packages/api/template/config.yml
+++ b/packages/api/template/config.yml
@@ -26,6 +26,9 @@ default:
       # Retention period for messages in SQS that will receive
       # the feed's STAC items
       MessageRetentionPeriod: 1209600
+      # Number of messages (items) processed at each
+      # lambda call
+      BatchSize: 10
 
   lambdas:
     landsat:

--- a/packages/sns-ingest/README.md
+++ b/packages/sns-ingest/README.md
@@ -1,0 +1,4 @@
+## @sat-utils/sns-ingest
+
+### About
+Sat API Lib was made by [Development Seed](http://developmentseed.org).

--- a/packages/sns-ingest/index.js
+++ b/packages/sns-ingest/index.js
@@ -1,0 +1,118 @@
+'use strict'
+
+const local = require('kes/src/local')
+const satlib = require('@sat-utils/api-lib')
+const request = require('request')
+
+function downloadJSON(url) {
+  return new Promise((resolve, reject) => {
+    request(url, (error, response, body) => {
+      if (error) reject(error)
+      if (response.statusCode !== 200) {
+        reject(`Invalid status code <${response.statusCode}>`)
+      }
+      resolve(body)
+    })
+  })
+}
+
+function handler(event, _context, _cb) {
+  //console.log(JSON.stringify(event))
+
+  // Build array with all STAC items
+  const importedStacItems = []
+  event.Records.forEach((record) => {
+    // load stac item
+    const body = JSON.parse(record.body)
+    const importedStacItem = JSON.parse(body.Message)
+    console.log(importedStacItem)
+    importedStacItems.push(importedStacItem)
+    //console.log(importedStacItem.geometry.coordinates[0][0][0][0])
+    //console.log(importedStacItem.geometry.coordinates[0][0][0][1])
+    //console.log(importedStacItem.geometry.coordinates[0][0][1][0])
+    //console.log(importedStacItem.geometry.coordinates[0][0][1][1])
+  })
+
+  satlib.es.client().then((client) => {
+    console.log('Connected to ES')
+
+    // Create a 'collection' index in ES
+    satlib.es.putMapping(client, 'collections').catch((_err) => {})
+
+    // traverse list and add collection if necessary
+    // satlib.es.client is an async function
+    importedStacItems.forEach((importedStacItem) => {
+      // Check if we need to import collection
+      console.log('Checking ', importedStacItem.properties['c:id'])
+      client.exists({
+        index: 'collections',
+        type: 'doc',
+        id: importedStacItem.properties['c:id']
+      }).then((collectionExists) => {
+        if (!collectionExists) {
+          // Read collection information and insert into ES
+          // Load collection from stac item
+          downloadJSON(importedStacItem.links.collection.href).then((body) => {
+            const importedCollection = JSON.parse(body)
+            console.log(importedCollection)
+            console.log(importedCollection.properties['c:id'])
+
+            // @todo repeating c:id parameter at first level, check 'c:id' passed
+            // to saveRecords below
+            importedCollection['c:id'] = importedCollection.properties['c:id']
+
+            // @todo check, had to remove index= named parameter
+            satlib.es.saveRecords(client, [importedCollection], 'collections', 'c:id',
+              (err, _updated, _errors) => {
+                if (err) console.log('Error: ', err)
+              })
+          })
+        }
+        else {
+          console.log('Collection', importedStacItem.properties['c:id'],
+            'already imported')
+        }
+      })
+    })
+    // Include all STAC items
+    satlib.es.saveRecords(client, importedStacItems, 'items', 'id', (err, _updated, _errors) => {
+      if (err) console.log('Error: ', err)
+    })
+  })
+}
+
+// to execute locally
+//   needs
+//     const local = require('kes/src/local')
+//   $ node index.js local
+//  connection to ES require process.env.ES_TEST_HOST
+local.localRun(() => {
+  console.log('running locally')
+
+  // Test event payload (single SQS message)
+  const a = {
+    Records: [
+      {
+        messageId: '7438ccd7-976c-461a-8422-190c1dd05826',
+        receiptHandle: '',
+        body: '{\n "Type" : "Notification",\n "MessageId" : "75a4b276-4fc5-5b19-bbd4-e1bb84f872d6",\n "TopicArn" : "arn:aws:sns:us-east-1:769537946825:cbers-2-stac-CBERSSTACItemTopic-N0MZUA5EIQC9",\n "Message" : "{\\"id\\": \\"CBERS_4_AWFI_20170202_163_135_L4\\", \\"type\\": \\"Feature\\", \\"bbox\\": [-62.623474, -35.166778, -51.450413, -26.896415], \\"geometry\\": {\\"type\\": \\"MultiPolygon\\", \\"coordinates\\": [[[[-62.520943, -33.720312], [-52.892548, -35.197403], [-51.389008, -28.427529], [-60.347934, -27.053129], [-62.520943, -33.720312]]]]}, \\"properties\\": {\\"datetime\\": \\"2017-02-02T13:58:04Z\\", \\"provider\\": \\"INPE\\", \\"eo:collection\\": \\"default\\", \\"eo:sun_azimuth\\": 69.6523, \\"eo:sun_elevation\\": 60.1348, \\"eo:off_nadir\\": -0.00834499, \\"eo:epsg\\": 32757, \\"cbers:data_type\\": \\"L4\\", \\"cbers:path\\": 163, \\"cbers:row\\": 135, \\"c:id\\": \\"CBERS_4_AWFI_L4\\"}, \\"links\\": {\\"self\\": {\\"rel\\": \\"self\\", \\"href\\": \\"https://cbers-stac.s3.amazonaws.com/CBERS4/AWFI/163/135/CBERS_4_AWFI_20170202_163_135_L4.json\\"}, \\"catalog\\": {\\"rel\\": \\"catalog\\", \\"href\\": \\"https://cbers-stac.s3.amazonaws.com/CBERS4/AWFI/163/catalog.json\\"}, \\"collection\\": {\\"rel\\": \\"collection\\", \\"href\\": \\"https://cbers-stac.s3.amazonaws.com/collections/CBERS_4_AWFI_L4_collection.json\\"}}, \\"assets\\": {\\"thumbnail\\": {\\"href\\": \\"https://s3.amazonaws.com/cbers-meta-pds/CBERS4/AWFI/163/135/CBERS_4_AWFI_20170202_163_135_L4/CBERS_4_AWFI_20170202_163_135.jpg\\", \\"type\\": \\"jpeg\\"}, \\"metadata\\": {\\"href\\": \\"s3://cbers-pds/CBERS4/AWFI/163/135/CBERS_4_AWFI_20170202_163_135_L4/CBERS_4_AWFI_20170202_163_135_L4_BAND14.xml\\", \\"type\\": \\"xml\\"}, \\"B13\\": {\\"href\\": \\"s3://cbers-pds/CBERS4/AWFI/163/135/CBERS_4_AWFI_20170202_163_135_L4/CBERS_4_AWFI_20170202_163_135_L4_BAND13.tif\\", \\"type\\": \\"GeoTIFF\\", \\"format\\": \\"COG\\", \\"eo_bands\\": [\\"13\\"]}, \\"B14\\": {\\"href\\": \\"s3://cbers-pds/CBERS4/AWFI/163/135/CBERS_4_AWFI_20170202_163_135_L4/CBERS_4_AWFI_20170202_163_135_L4_BAND14.tif\\", \\"type\\": \\"GeoTIFF\\", \\"format\\": \\"COG\\", \\"eo_bands\\": [\\"14\\"]}, \\"B15\\": {\\"href\\": \\"s3://cbers-pds/CBERS4/AWFI/163/135/CBERS_4_AWFI_20170202_163_135_L4/CBERS_4_AWFI_20170202_163_135_L4_BAND15.tif\\", \\"type\\": \\"GeoTIFF\\", \\"format\\": \\"COG\\", \\"eo_bands\\": [\\"15\\"]}, \\"B16\\": {\\"href\\": \\"s3://cbers-pds/CBERS4/AWFI/163/135/CBERS_4_AWFI_20170202_163_135_L4/CBERS_4_AWFI_20170202_163_135_L4_BAND16.tif\\", \\"type\\": \\"GeoTIFF\\", \\"format\\": \\"COG\\", \\"eo_bands\\": [\\"16\\"]}}}",\n "Timestamp" : "2018-07-21T23:59:57.306Z",\n "SignatureVersion" : "1",\n "Signature" : "FrgcguM0cCxptNw69h+8+XJDxU4MDGIoRVWn63zM4061Kaa4GvoH8yHrgeD9uY39mohJTj3sFhNmJiOc+PEeFk6jDqnQlE0Qfo5pNDqJ0w85Fs4J4J2tMM9dv+pWPvO/rTSjumjxlM/HTnqz8AWsX3JipphobldkbKhuO/89A7KyWmCDH4FcvCt4SxfQNpYQDfreh1zlv0nzOW6/+gMjND6FXGcvZBJjwPeuzrYRME1VB2qeRaojmxxN4ftJ8PGcN2orPCwEugnDXSUuHqHXWCexQ/dRG4wEuleWHXg21he9QR/AMAyKfC0NMhaB7Hi4YE/+5uSybYYJGHSEMzQQBg==",\n "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-eaea6120e66ea12e88dcd8bcbddca752.pem",\n "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:769537946825:cbers-2-stac-CBERSSTACItemTopic-N0MZUA5EIQC9:27d89923-20b3-4208-b012-47ed0dfd7918",\n "MessageAttributes" : {\n "bbox.ur_lon" : {"Type":"Number","Value":"-51.450413"},\n "bbox.ur_lat" : {"Type":"Number","Value":"-26.896415"},\n "links.self.href" : {"Type":"String","Value":"https://cbers-stac.s3.amazonaws.com/CBERS4/AWFI/163/135/CBERS_4_AWFI_20170202_163_135_L4.json"},\n "bbox.ll_lon" : {"Type":"Number","Value":"-62.623474"},\n "properties.datetime" : {"Type":"String","Value":"2017-02-02T13:58:04Z"},\n "bbox.ll_lat" : {"Type":"Number","Value":"-35.166778"},\n "properties.c.id" : {"Type":"String","Value":"CBERS_4_AWFI_L4"}\n }\n}',
+        attributes: [Object],
+        messageAttributes: {},
+        md5OfBody: 'b0c84e1710389da6a2b36afa0021bf7f',
+        eventSource: 'aws:sqs',
+        eventSourceARN: 'arn:aws:sqs:us-east-1:769537946825:STACItemTest',
+        awsRegion: 'us-east-1'
+      }]
+  }
+
+  handler(a, null, (err, r) => {
+    if (err) {
+      console.log(`error: ${err}`)
+    }
+    else {
+      console.log(`success: ${r}`)
+    }
+  })
+})
+
+module.exports.handler = handler

--- a/packages/sns-ingest/package.json
+++ b/packages/sns-ingest/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@sat-utils/sns-ingest",
+  "version": "0.0.1",
+  "description": "Lambda function for ingesting stac metadata from SNS/SQS to sat-api",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sat-utils/sat-api.git"
+  },
+  "author": "Alireza Jazayeri <alireza@developmentseed.org>, Matthew Hanson <matt.a.hanson@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sat-utils/sat-api/issues"
+  },
+  "scripts": {
+    "build": "webpack"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/sat-utils/sat-api#readme",
+  "dependencies": {
+    "@sat-utils/api-lib": "^0.0.2"
+   },
+  "devDependencies": {
+    "aws-sdk": "^2.272.1",
+    "webpack": "~4.5.0",
+    "webpack-cli": "~2.0.14"
+  }
+}

--- a/packages/sns-ingest/webpack.config.js
+++ b/packages/sns-ingest/webpack.config.js
@@ -1,0 +1,27 @@
+
+const path = require('path');
+
+let mode = 'development';
+let devtool = 'inline-source-map';
+
+if(process.env.PRODUCTION) {
+  mode = 'production',
+  devtool = false  
+}
+
+module.exports = {
+  mode,
+  entry: './index.js',
+  output: {
+    libraryTarget: 'commonjs2',
+    filename: 'index.js',
+    path: path.resolve(__dirname, 'dist')
+  },
+  externals: [
+    'aws-sdk',
+    'electron',
+    {'formidable': 'url'}
+  ],
+  devtool,
+  target: 'node'
+};


### PR DESCRIPTION
This replaces PR #54 with the new packaging structure.

To-do
  - [x] Read collection information and update ES only if needed
  - [x] Ingest batch of items
  - [x] Integrate with SNS/SQS
  - [ ] Check duplicated 'c:id' parameter, needed to interface with sat-api-lib
  - [x] Check async for lambda handler
  - [x] Update KES configuration to include new cloud resources
  - [ ] Update documentation
    - [ ] ES_TEST_HOST 
    - [ ] How to deploy new SNS feed)