### PR TITLE
change ES precision for geometry searches, add envvar to change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `fields` filter to return only specific fields
 - Added SATAPI_URL environment variable for defining a custom root URL used for creating hierarchical links. Otherwise, the root URL will try to be inferred from the headers.
 - Gzip compression added for clients that support it (via `Accept-Encoding`)
+- Added SATAPI_ES_PRECISION environment variable to change the precision for underlying intersection geometry queries. 
 
 ### Fixed
 - Fix datetime range to be inclusive (i.e., gte and lte)
 - Fixed `next` links to properly stringify geometries
+
+### Changed
+- Default precision for geometry queries in the Elasticsearch backend is now 50meters rather than 5miles.  As this may have an adverse impact on performance, it can be changed by setting the SATAPI_ES_PRECISION envvar. If changed after ingestion, a reindex operation will need to be performed. Use "5mi" to keep the old value.
 
 
 ## [v0.2.3] - 2019-01-29

--- a/packages/api-lib/libs/es.js
+++ b/packages/api-lib/libs/es.js
@@ -105,7 +105,7 @@ async function prepare(index) {
   const client = await esClient()
   const indexExists = await client.indices.exists({ index })
   if (!indexExists) {
-    const precision = process.env.SATAPI_ES_PRECISION || "50m"
+    const precision = process.env.SATAPI_ES_PRECISION || '50m'
     const payload = {
       index,
       body: {

--- a/packages/api-lib/libs/es.js
+++ b/packages/api-lib/libs/es.js
@@ -105,6 +105,7 @@ async function prepare(index) {
   const client = await esClient()
   const indexExists = await client.indices.exists({ index })
   if (!indexExists) {
+    const precision = process.env.SATAPI_ES_PRECISION || "50m"
     const payload = {
       index,
       body: {
@@ -120,7 +121,7 @@ async function prepare(index) {
               geometry: {
                 type: 'geo_shape',
                 tree: 'quadtree',
-                precision: '5mi'
+                precision: precision
               }
             }
           }


### PR DESCRIPTION
Adds a new env var, SATAPI_ES_PRECISION to change the default precision for geometry queries.

The old value was 5mi, which led to matching scenes even when the AOI was well outside the scene footprint.

Without setting it, the new default value will be '50m' (meters), which is the default for Elasticsearch.

resolves #178

If the precision is changed in the index after there is already data, then the data will need to be reindexed.