### PR TITLE
Remove gzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.2.5] - 2019-06-17
+
+### Fixed
+- Added missing dependency (through2)
+
+### Removed
+- Removed gzip compression which caused problems with APIGateway. Use APIGateway to enable compression instead rather than in the library.
+
 ## [v0.2.4] - 2019-06-02
 
 ### Added
@@ -97,6 +105,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Refactor and improve splitting
 
 [Unreleased]: https://github.com/sat-utils/sat-api/compare/master...develop
+[v0.2.5]: https://github.com/sat-utils/sat-api/compare/v0.2.4...v0.2.5
 [v0.2.4]: https://github.com/sat-utils/sat-api/compare/v0.2.3...v0.2.4
 [v0.2.3]: https://github.com/sat-utils/sat-api/compare/v0.2.2...v0.2.3
 [v0.2.2]: https://github.com/sat-utils/sat-api/compare/v0.2.1...v0.2.2

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -2,10 +2,7 @@
 
 'use strict'
 
-const zlib = require('zlib')
-const { promisify } = require('util')
 const satlib = require('@sat-utils/api-lib')
-const gzip = promisify(zlib.gzip)
 
 module.exports.handler = async (event) => {
   // determine endpoint
@@ -21,32 +18,15 @@ module.exports.handler = async (event) => {
     }
   }
 
-  const lowerCaseHeaders = (headers) => Object.entries(headers).reduce(
-    (acc, [key, value]) => {
-      acc[typeof key === 'string' ? key.toLowerCase() : key] = value
-      return acc
-    }, {}
-  )
-
   const buildResponse = async (statusCode, result) => {
-    const headers = lowerCaseHeaders(event.headers)
-    const acceptEncoding = headers['accept-encoding'] || ''
-    const encodings = acceptEncoding.split(',')
-    const isGzip = encodings.includes('gzip')
     const response = {
       statusCode,
       headers: {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Origin': '*', // Required for CORS support to work
         'Access-Control-Allow-Credentials': true
-      }
-    }
-    if (isGzip) {
-      const zipped = await gzip(result)
-      response.body = zipped.toString('base64')
-      response.headers['Content-Encoding'] = 'gzip'
-    } else {
-      response.body = result
+      },
+      body: result
     }
     return response
   }

--- a/packages/api/tests/test_handler.js
+++ b/packages/api/tests/test_handler.js
@@ -2,9 +2,6 @@ const test = require('ava')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const createEvent = require('aws-event-mocks')
-const zlib = require('zlib')
-const { promisify } = require('util')
-const gunzip = promisify(zlib.gunzip)
 
 test('handler calls search with parameters', async (t) => {
   const result = { value: 'value' }
@@ -83,58 +80,4 @@ test('handler returns 404 for error', async (t) => {
   const actual = await lambda.handler(event)
   t.is(actual.statusCode, 404)
   t.is(actual.body, errorMessage)
-})
-
-test('handler gzips response', async (t) => {
-  const result = { value: 'value' }
-  const search = sinon.stub().resolves(result)
-  const satlib = {
-    api: {
-      search
-    }
-  }
-  const lambda = proxyquire('../index.js', {
-    '@sat-utils/api-lib': satlib
-  })
-  const host = 'host'
-  const httpMethod = 'GET'
-  const path = 'path'
-
-  let event = createEvent({
-    template: 'aws:apiGateway',
-    merge: {
-      headers: {
-        Host: host,
-        'accept-encoding': 'gzip, deflate'
-      },
-      requestContext: {},
-      httpMethod,
-      path
-    }
-  })
-
-  let actual = await lambda.handler(event)
-  t.is(actual.statusCode, 200)
-  let unzippedBody = await gunzip(Buffer.from(actual.body, 'base64'))
-  t.is(unzippedBody.toString(), JSON.stringify(result))
-  t.is(actual.headers['Content-Encoding'], 'gzip')
-
-  event = createEvent({
-    template: 'aws:apiGateway',
-    merge: {
-      headers: {
-        Host: host,
-        'Accept-Encoding': 'gzip, deflate'
-      },
-      requestContext: {},
-      httpMethod,
-      path
-    }
-  })
-
-  actual = await lambda.handler(event)
-  t.is(actual.statusCode, 200)
-  unzippedBody = await gunzip(Buffer.from(actual.body, 'base64'))
-  t.is(unzippedBody.toString(), JSON.stringify(result),
-    'Ignores header case sensitivity')
 })


### PR DESCRIPTION
This removes gzip in order to release a working 0.2.5.

gzip compression can be readded in 0.3.0, or can possibly just be enabled directly in APIGateway and remain out of the code.