### PR TITLE
support ingest of s3:// urls

### DIFF
--- a/packages/api-lib/package.json
+++ b/packages/api-lib/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@mapbox/extent": "^0.4.0",
     "@turf/helpers": "^6.1.4",
+    "aws-sdk": "^2.382.0",
     "bottleneck": "^2.13.1",
     "elasticsearch": "^14.2.2",
     "geojson-validation": "^0.1.6",
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
-    "aws-sdk": "^2.382.0",
     "nock": "^8.0.0",
     "proxyquire": "^2.1.0",
     "sinon": "^7.1.1"

--- a/packages/api-lib/tests/test_ingest.js
+++ b/packages/api-lib/tests/test_ingest.js
@@ -3,7 +3,9 @@ const sinon = require('sinon')
 const MemoryStream = require('memorystream')
 const proxquire = require('proxyquire')
 const fs = require('fs')
-const { ingest, ingestItem } = require('../libs/ingest')
+const {
+  ingest, ingestItem, getS3ParamsFromUrl, getS3Object
+} = require('../libs/ingest')
 const firstItem = require('./fixtures/stac/LC80100102015050LGN00.json')
 
 const setup = () => {
@@ -95,4 +97,45 @@ test('ingestItem passes item through transform stream', async (t) => {
   const { esStream, backend } = setup()
   await ingestItem(firstItem, backend)
   t.deepEqual(esStream.queue[0], firstItem)
+})
+
+test('getS3ParamsFromUrl parses s3 url correctly', async (t) => {
+  let url = 's3://bucket-name/this/is/the/key'
+  let result = getS3ParamsFromUrl(url)
+  t.is(result.Bucket, 'bucket-name')
+  t.is(result.Key, 'this/is/the/key')
+
+  url = 's3://bucket-name/simplekey'
+  result = getS3ParamsFromUrl(url)
+  t.is(result.Bucket, 'bucket-name')
+  t.is(result.Key, 'simplekey')
+
+  url = 's3://landsat-pds/c1/L8/040/036/LC08_L1TP_040036_20190216_20190216_01_RT'
+  result = getS3ParamsFromUrl(url)
+  t.is(result.Bucket, 'landsat-pds')
+  t.is(result.Key, 'c1/L8/040/036/LC08_L1TP_040036_20190216_20190216_01_RT')
+})
+
+test('getS3ParamsFromUrl throws exception on invalid s3 url', async (t) => {
+  const badUrls = ['asdf', 's3://bucket-name/', 's3://bucket-name',
+    's3:///key', 's3:///', 's3://']
+
+  badUrls.forEach((url) => {
+    const error = t.throws(() => getS3ParamsFromUrl(url))
+    t.truthy(error.message.includes('cannot parse bucket/key'))
+  })
+})
+
+test('getS3Object rejects promise on invalid s3 url', async (t) => {
+  const badUrls = ['asdf', 's3://bucket-name/', 's3://bucket-name',
+    's3:///key', 's3:///', 's3://']
+
+  badUrls.forEach(async (url) => {
+    // note throwsAsync appears to require upgrade to Ava version
+    // const error = await t.throwsAsync(promise)
+
+    const promise = getS3Object(url)
+    const error = await t.throws(promise)
+    t.truthy(error.message.includes('cannot parse bucket/key'))
+  })
 })


### PR DESCRIPTION
This is an implementation of #187 (support ingest of private/requester pays S3 buckets). If a url starts with `s3://`, it will use aws-sdk to download the file contents instead of failing due to unrecognized protocol.

Note, I moved aws-sdk into `dependencies` from `devDependencies` for api-lib.

This will support requester pays buckets if you set the environment variable: 
```
AWS_REQUEST_PAYER=requester
```

I tested this on my end with some simple test scripts but haven't implemented a proper sat-api test yet. I'm willing to do that but I'll need some guidance on what your expectations would be there!

Thanks 😃 