### PR TITLE
fix typo for include/exclude fields filters

### DIFF
--- a/packages/api-lib/libs/es.js
+++ b/packages/api-lib/libs/es.js
@@ -363,23 +363,23 @@ function buildFieldsFilter(parameters) {
   const _sourceInclude = []
   const _sourceExclude = []
   if (fields) {
-    const { geometry, includes, excludes } = fields
+    const { geometry, include, exclude } = fields
     if (typeof geometry !== 'undefined' && !geometry) {
       _sourceExclude.push('geometry')
     }
-    if (includes && includes.length > 0) {
-      const propertiesIncludes = includes.map(
+    if (include && include.length > 0) {
+      const propertiesIncludes = include.map(
         (field) => (`properties.${field}`)
       ).concat(
         [id, type, bbox, links, assets]
       )
       _sourceInclude.push(...propertiesIncludes)
     }
-    if (excludes && excludes.length > 0) {
-      const filteredExcludes = excludes.filter((field) =>
-        (![id, type, bbox, links, assets].includes(field)))
-      const propertiesExcludes = filteredExcludes.map((field) => (`properties.${field}`))
-      _sourceExclude.push(...propertiesExcludes)
+    if (exclude && exclude.length > 0) {
+      const filteredExcludes = exclude.filter((field) =>
+        (![id, type, bbox, links, assets].include(field)))
+      const propertiesExclude = filteredExcludes.map((field) => (`properties.${field}`))
+      _sourceExclude.push(...propertiesExclude)
     }
   }
   return { _sourceExclude, _sourceInclude }

--- a/packages/api-lib/tests/integration/test_api.js
+++ b/packages/api-lib/tests/integration/test_api.js
@@ -187,7 +187,7 @@ test('stac/search flattened collection properties', async (t) => {
 test('stac/search fields filter', async (t) => {
   let response = await search('/stac/search', {
     fields: {
-      excludes: ['collection']
+      exclude: ['collection']
     }
   }, backend, endpoint)
   t.falsy(response.features[0].properties.collection)
@@ -208,7 +208,7 @@ test('stac/search fields filter', async (t) => {
 
   response = await search('/stac/search', {
     fields: {
-      includes: ['collection', 'eo:epsg']
+      include: ['collection', 'eo:epsg']
     }
   }, backend, endpoint)
   t.truthy(response.features[0].properties.collection)
@@ -217,7 +217,7 @@ test('stac/search fields filter', async (t) => {
 
   response = await search('/stac/search', {
     fields: {
-      excludes: ['id', 'links']
+      exclude: ['id', 'links']
     }
   }, backend, endpoint)
   t.truthy(response.features.length, 'Does not exclude required fields')


### PR DESCRIPTION
per https://github.com/radiantearth/stac-spec/tree/master/api-spec/extensions/fields#includeexclude-semantics `include/exclude` filters doesn't have `s`

cc @sharkinsspatial @matthewhanson 